### PR TITLE
Add and correct various VIFE units and return Reserved on unknown

### DIFF
--- a/crates/m-bus-application-layer/src/value_information.rs
+++ b/crates/m-bus-application-layer/src/value_information.rs
@@ -299,13 +299,27 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                         decimal_scale_exponent +=
                             (value_information_block.value_information.data & 0b111) as isize - 3;
                     }
-                    0x58..=0x5F | 0x64..=0x67 => {
+                    0x58..=0x5B => {
                         units.push(unit!(Celsius));
+                        labels.push(ValueLabel::FlowTemperature);
+                        decimal_scale_exponent +=
+                            (value_information_block.value_information.data & 0b11) as isize - 3;
+                    }
+                    0x5C..=0x5F => {
+                        units.push(unit!(Celsius));
+                        labels.push(ValueLabel::ReturnTemperature);
                         decimal_scale_exponent +=
                             (value_information_block.value_information.data & 0b11) as isize - 3;
                     }
                     0x60..=0x63 => {
                         units.push(unit!(Kelvin));
+                        labels.push(ValueLabel::TemperatureDifference);
+                        decimal_scale_exponent +=
+                            (value_information_block.value_information.data & 0b11) as isize - 3;
+                    }
+                    0x64..=0x67 => {
+                        units.push(unit!(Celsius));
+                        labels.push(ValueLabel::ExternalTemperature);
                         decimal_scale_exponent +=
                             (value_information_block.value_information.data & 0b11) as isize - 3;
                     }
@@ -441,9 +455,13 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                         units.push(unit!(Day));
                         labels.push(ValueLabel::PeriodOfNormalDataTransmition);
                     }
-                    0x50..=0x5F => {
+                    0x40..=0x4F => {
                         units.push(unit!(Volt));
                         decimal_scale_exponent = (first_vife_data & 0b1111) as isize - 9;
+                    }
+                    0x50..=0x5F => {
+                        units.push(unit!(Ampere));
+                        decimal_scale_exponent = (first_vife_data & 0b1111) as isize - 12;
                     }
                     0x60 => labels.push(ValueLabel::ResetCounter),
                     0x61 => labels.push(ValueLabel::CumulationCounter),
@@ -529,6 +547,11 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                         units.push(mk_unit(Hour, -1));
                         populate!(@snd $($rem)*)
                     }};
+                    ($name:ident / min, $exponent:expr, $($rem:tt)*) => {{
+                        units.push(mk_unit($name, $exponent));
+                        units.push(mk_unit(Minute, -1));
+                        populate!(@snd $($rem)*)
+                    }};
                     ($name:ident * h, $exponent:expr, $($rem:tt)*) => {{
                         units.push(mk_unit($name, $exponent));
                         units.push(mk_unit(Hour, 1));
@@ -564,8 +587,12 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                     0b001_1000 => populate!(Tonne, 1, dec: 2),
                     0b001_1001 => populate!(Tonne, 1, dec: 3),
                     0b001_1010 => populate!(Percent, 1, dec: -1, RelativeHumidity),
-                    0b010_0000 => populate!(Feet, 3, dec: 0),
-                    0b010_0001 => populate!(Feet, 3, dec: 1),
+                    0b010_0001 => populate!(Feet, 3, dec: -1),
+                    0b010_0010 => populate!(AmericanGallon, 1, dec: -1),
+                    0b010_0011 => populate!(AmericanGallon, 1, dec: 0),
+                    0b010_0100 => populate!(AmericanGallon / min, 1, dec: -3),
+                    0b010_0101 => populate!(AmericanGallon / min, 1, dec: 0),
+                    0b010_0110 => populate!(AmericanGallon / h, 1, dec: 0),
                     0b010_1000 => populate!(Watt, 1, dec: 5),
                     0b010_1001 => populate!(Watt, 1, dec: 6),
                     0b010_1010 => populate!(Degree, 1, dec: -1, PhaseUtoU),
@@ -580,6 +607,26 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                     0b011_0101 => populate!(ApparentWatt / h, 1, dec: 1),
                     0b011_0110 => populate!(ApparentWatt / h, 1, dec: 2),
                     0b011_0111 => populate!(ApparentWatt / h, 1, dec: 3),
+                    0b101_1000 => populate!(Fahrenheit, 1, dec: -3, FlowTemperature),
+                    0b101_1001 => populate!(Fahrenheit, 1, dec: -2, FlowTemperature),
+                    0b101_1010 => populate!(Fahrenheit, 1, dec: -1, FlowTemperature),
+                    0b101_1011 => populate!(Fahrenheit, 1, dec: 0, FlowTemperature),
+                    0b101_1100 => populate!(Fahrenheit, 1, dec: -3, ReturnTemperature),
+                    0b101_1101 => populate!(Fahrenheit, 1, dec: -2, ReturnTemperature),
+                    0b101_1110 => populate!(Fahrenheit, 1, dec: -1, ReturnTemperature),
+                    0b101_1111 => populate!(Fahrenheit, 1, dec: 0, ReturnTemperature),
+                    0b110_0000 => populate!(Fahrenheit, 1, dec: -3, TemperatureDifference),
+                    0b110_0001 => populate!(Fahrenheit, 1, dec: -2, TemperatureDifference),
+                    0b110_0010 => populate!(Fahrenheit, 1, dec: -1, TemperatureDifference),
+                    0b110_0011 => populate!(Fahrenheit, 1, dec: 0, TemperatureDifference),
+                    0b110_0100 => populate!(Fahrenheit, 1, dec: -3, ExternalTemperature),
+                    0b110_0101 => populate!(Fahrenheit, 1, dec: -2, ExternalTemperature),
+                    0b110_0110 => populate!(Fahrenheit, 1, dec: -1, ExternalTemperature),
+                    0b110_0111 => populate!(Fahrenheit, 1, dec: 0, ExternalTemperature),
+                    0b111_0000 => populate!(Fahrenheit, 1, dec: -3, ColdWarmTemperatureLimit),
+                    0b111_0001 => populate!(Fahrenheit, 1, dec: -2, ColdWarmTemperatureLimit),
+                    0b111_0010 => populate!(Fahrenheit, 1, dec: -1, ColdWarmTemperatureLimit),
+                    0b111_0011 => populate!(Fahrenheit, 1, dec: 0, ColdWarmTemperatureLimit),
                     0b111_0100 => populate!(Celsius, 1, dec: -3, ColdWarmTemperatureLimit),
                     0b111_0101 => populate!(Celsius, 1, dec: -2, ColdWarmTemperatureLimit),
                     0b111_0110 => populate!(Celsius, 1, dec: -1, ColdWarmTemperatureLimit),
@@ -602,11 +649,7 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                     0b110_1101 => populate!(HCAUnit, 1,dec: 0, LowTemperatureRatingFactor),
                     0b110_1110 => populate!(HCAUnit, 1,dec: 0, DisplayOutputScalingFactor),
 
-                    _ => {
-                        return Err(DataInformationError::Unimplemented {
-                            feature: "Extended value information unit codes (partial)",
-                        })
-                    }
+                    _ => labels.push(ValueLabel::Reserved),
                 };
             }
             // we need to check if the next byte is equivalent to the length of the rest of the
@@ -1114,6 +1157,8 @@ pub enum ValueLabel {
     Volume,
     FlowTemperature,
     ReturnTemperature,
+    TemperatureDifference,
+    ExternalTemperature,
 }
 
 #[cfg(feature = "std")]
@@ -1206,6 +1251,8 @@ pub enum UnitName {
     Degree,
     Hertz,
     HCAUnit,
+    Fahrenheit,
+    AmericanGallon,
 }
 
 #[cfg(feature = "std")]
@@ -1240,7 +1287,7 @@ impl fmt::Display for UnitName {
             UnitName::InputPulseOnChannel1 => write!(f, "InputPulseOnChannel1"),
             UnitName::OutputPulseOnChannel1 => write!(f, "OutputPulseOnChannel1"),
             UnitName::Liter => write!(f, "l"),
-            UnitName::Volt => write!(f, "A"),
+            UnitName::Volt => write!(f, "V"),
             UnitName::Ampere => write!(f, "A"),
             UnitName::LocalMoneyCurrency => write!(f, "$ (local)"),
             UnitName::Symbol => write!(f, "Symbol"),
@@ -1250,6 +1297,8 @@ impl fmt::Display for UnitName {
             UnitName::Degree => write!(f, "°"),
             UnitName::Hertz => write!(f, "Hz"),
             UnitName::HCAUnit => write!(f, "HCAUnit"),
+            UnitName::Fahrenheit => write!(f, "°F"),
+            UnitName::AmericanGallon => write!(f, "UsGal"),
         }
     }
 }
@@ -1506,5 +1555,56 @@ mod tests {
         let data = [253, 27];
         let result = ValueInformationBlock::try_from(data.as_slice()).unwrap();
         assert_eq!(result.get_size(), 2);
+    }
+
+    #[test]
+    fn test_vif_fd_voltage_and_ampere() {
+        use crate::value_information::UnitName;
+        use crate::value_information::{ValueInformation, ValueInformationBlock};
+
+        // VIF=0xFD VIFE=0x48: Voltage 10^(8-9) = 0.1 V
+        let vi = ValueInformation::try_from(
+            &ValueInformationBlock::try_from([0xFD, 0x48].as_slice()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(vi.units[0].name, UnitName::Volt);
+        assert_eq!(vi.decimal_scale_exponent, -1);
+
+        // VIF=0xFD VIFE=0x59: Ampere 10^(9-12) = 0.001 A
+        let vi = ValueInformation::try_from(
+            &ValueInformationBlock::try_from([0xFD, 0x59].as_slice()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(vi.units[0].name, UnitName::Ampere);
+        assert_eq!(vi.decimal_scale_exponent, -3);
+    }
+
+    #[test]
+    fn test_vif_fb_added_codes_and_reserved_fallback() {
+        use crate::value_information::UnitName;
+        use crate::value_information::{ValueInformation, ValueInformationBlock, ValueLabel};
+
+        // VIF=0xFB VIFE=0x22: US gallon, 10^-1
+        let vi = ValueInformation::try_from(
+            &ValueInformationBlock::try_from([0xFB, 0x22].as_slice()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(vi.units[0].name, UnitName::AmericanGallon);
+        assert_eq!(vi.decimal_scale_exponent, -1);
+
+        // VIF=0xFB VIFE=0x70: °F cold/warm temp limit, 10^-3
+        let vi = ValueInformation::try_from(
+            &ValueInformationBlock::try_from([0xFB, 0x70].as_slice()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(vi.units[0].name, UnitName::Fahrenheit);
+        assert_eq!(vi.decimal_scale_exponent, -3);
+
+        // VIF=0xFB VIFE=0x20 (E010 0000): Reserved per EN 13757-3 — should not error
+        let vi = ValueInformation::try_from(
+            &ValueInformationBlock::try_from([0xFB, 0x20].as_slice()).unwrap(),
+        )
+        .unwrap();
+        assert!(vi.labels.contains(&ValueLabel::Reserved));
     }
 }

--- a/crates/m-bus-application-layer/src/value_information.rs
+++ b/crates/m-bus-application-layer/src/value_information.rs
@@ -351,6 +351,7 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                     &mut units,
                     &mut decimal_scale_exponent,
                     &mut decimal_offset_exponent,
+                    false,
                 );
             }
             ValueInformationCoding::MainVIFExtension => {
@@ -455,6 +456,7 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                         units.push(unit!(Day));
                         labels.push(ValueLabel::PeriodOfNormalDataTransmition);
                     }
+                    0x3A => labels.push(ValueLabel::Dimensionless),
                     0x40..=0x4F => {
                         units.push(unit!(Volt));
                         decimal_scale_exponent = (first_vife_data & 0b1111) as isize - 9;
@@ -530,6 +532,14 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                     },
                     _ => labels.push(ValueLabel::Reserved),
                 }
+                consume_orthhogonal_vife(
+                    value_information_block,
+                    &mut labels,
+                    &mut units,
+                    &mut decimal_scale_exponent,
+                    &mut decimal_offset_exponent,
+                    true,
+                );
             }
             ValueInformationCoding::AlternateVIFExtension => {
                 use UnitName::*;
@@ -587,6 +597,7 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                     0b001_1000 => populate!(Tonne, 1, dec: 2),
                     0b001_1001 => populate!(Tonne, 1, dec: 3),
                     0b001_1010 => populate!(Percent, 1, dec: -1, RelativeHumidity),
+                    0b001_1011 => populate!(Percent, 1, dec: 0, RelativeHumidity),
                     0b010_0001 => populate!(Feet, 3, dec: -1),
                     0b010_0010 => populate!(AmericanGallon, 1, dec: -1),
                     0b010_0011 => populate!(AmericanGallon, 1, dec: 0),
@@ -651,6 +662,14 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
 
                     _ => labels.push(ValueLabel::Reserved),
                 };
+                consume_orthhogonal_vife(
+                    value_information_block,
+                    &mut labels,
+                    &mut units,
+                    &mut decimal_scale_exponent,
+                    &mut decimal_offset_exponent,
+                    true,
+                );
             }
             // we need to check if the next byte is equivalent to the length of the rest of the
             // the data. In this case it is very likely that, this is how the payload is built up.
@@ -669,16 +688,20 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
     }
 }
 
+/// When `skip_extension_vife` is true, the first VIFE is skipped because it is
+/// the 0xFD/0xFB extension code already consumed by the main VIF match.
 fn consume_orthhogonal_vife(
     value_information_block: &ValueInformationBlock,
     labels: &mut ArrayVec<ValueLabel, 10>,
     units: &mut ArrayVec<Unit, 10>,
     decimal_scale_exponent: &mut isize,
     decimal_offset_exponent: &mut isize,
+    skip_extension_vife: bool,
 ) {
     if let Some(vife) = &value_information_block.value_information_extension {
+        let skip = if skip_extension_vife { 1 } else { 0 };
         let mut is_extension_of_combinable_orthogonal_vife = false;
-        for v in vife {
+        for v in vife.iter().skip(skip) {
             if v.data == 0xFC {
                 is_extension_of_combinable_orthogonal_vife = true;
                 continue;
@@ -1102,6 +1125,7 @@ pub enum ValueLabel {
     SizeOfStorageBlock,
     DescripitonOfTariffAndSubunit,
     StorageInterval,
+    Dimensionless,
     DimensionlessHCA,
     DataContainerForWmbusProtocol,
     PeriodOfNormalDataTransmition,
@@ -1606,5 +1630,55 @@ mod tests {
         )
         .unwrap();
         assert!(vi.labels.contains(&ValueLabel::Reserved));
+    }
+
+    #[test]
+    fn test_fb_humidity_with_combinatorial_scale() {
+        use crate::value_information::{ValueInformation, ValueInformationBlock, ValueLabel, UnitName};
+
+        // VIF=0xFB, VIFE=0x9B (0x1B + extension bit), VIFE2=0x74 (multiplicative 10^(4-6) = 10^-2)
+        // OMS RH01: relative humidity 10^0 %, shifted to 10^-2 by combinatorial.
+        let vi = ValueInformation::try_from(
+            &ValueInformationBlock::try_from([0xFB, 0x9B, 0x74].as_slice()).unwrap(),
+        )
+        .unwrap();
+
+        assert!(vi.labels.contains(&ValueLabel::RelativeHumidity));
+        assert_eq!(vi.units[0].name, UnitName::Percent);
+        assert_eq!(vi.decimal_scale_exponent, -2);
+    }
+
+    #[test]
+    fn test_fd_ampere_with_phase_combinatorial() {
+        use crate::value_information::{ValueInformation, ValueInformationBlock, ValueLabel, UnitName};
+
+        // VIF=0xFD, VIFE=0xD9 (0x59 + extension bit = Ampere 10^-3),
+        // VIFE2=0xFC (combinatorial extension), VIFE3=0x01 (AtPhaseL1)
+        // OMS CA01: per-phase current.
+        let vi = ValueInformation::try_from(
+            &ValueInformationBlock::try_from([0xFD, 0xD9, 0xFC, 0x01].as_slice()).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(vi.units[0].name, UnitName::Ampere);
+        assert_eq!(vi.decimal_scale_exponent, -3);
+        assert!(vi.labels.contains(&ValueLabel::AtPhaseL1));
+    }
+
+    #[test]
+    fn test_primary_vif_combinatorial_not_skipped() {
+        use crate::value_information::{ValueInformation, ValueInformationBlock, ValueLabel, UnitName};
+
+        // VIF=0xE5 (0x65 + extension bit = External temperature 10^-2),
+        // VIFE=0x74 (multiplicative 10^(4-6) = 10^-2)
+        // First VIFE must NOT be skipped for primary VIFs — total should be 10^-4.
+        let vi = ValueInformation::try_from(
+            &ValueInformationBlock::try_from([0xE5, 0x74].as_slice()).unwrap(),
+        )
+        .unwrap();
+
+        assert!(vi.labels.contains(&ValueLabel::ExternalTemperature));
+        assert_eq!(vi.units[0].name, UnitName::Celsius);
+        assert_eq!(vi.decimal_scale_exponent, -4);
     }
 }

--- a/crates/m-bus-application-layer/src/value_information.rs
+++ b/crates/m-bus-application-layer/src/value_information.rs
@@ -294,7 +294,7 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
                             (value_information_block.value_information.data & 0b111) as isize - 9;
                     }
                     0x50..=0x57 => {
-                        units.push(unit!(Kilogram ^ 3));
+                        units.push(unit!(Kilogram));
                         units.push(unit!(Hour ^ -1));
                         decimal_scale_exponent +=
                             (value_information_block.value_information.data & 0b111) as isize - 3;
@@ -673,7 +673,17 @@ impl TryFrom<&ValueInformationBlock> for ValueInformation {
             }
             // we need to check if the next byte is equivalent to the length of the rest of the
             // the data. In this case it is very likely that, this is how the payload is built up.
-            ValueInformationCoding::PlainText => labels.push(ValueLabel::PlainText),
+            ValueInformationCoding::PlainText => {
+                labels.push(ValueLabel::PlainText);
+                consume_orthhogonal_vife(
+                    value_information_block,
+                    &mut labels,
+                    &mut units,
+                    &mut decimal_scale_exponent,
+                    &mut decimal_offset_exponent,
+                    false,
+                );
+            }
             ValueInformationCoding::ManufacturerSpecific => {
                 labels.push(ValueLabel::ManufacturerSpecific)
             }
@@ -906,6 +916,10 @@ fn consume_orthhogonal_vife(
                         units.push(unit!(Minute));
                     }
                     0x66 => {
+                        labels.push(ValueLabel::DurationOfLast);
+                        units.push(unit!(Hour));
+                    }
+                    0x67 => {
                         labels.push(ValueLabel::DurationOfLast);
                         units.push(unit!(Day));
                     }
@@ -1552,7 +1566,7 @@ mod tests {
             ValueInformation::try_from(&result).unwrap(),
             ValueInformation {
                 decimal_offset_exponent: 0,
-                decimal_scale_exponent: 0,
+                decimal_scale_exponent: -2,
                 units: { ArrayVec::<Unit, 10>::new() },
                 labels: {
                     let mut x = ArrayVec::<ValueLabel, 10>::new();

--- a/src/mbus_data.rs
+++ b/src/mbus_data.rs
@@ -1633,7 +1633,7 @@ mod tests {
         let input = "68 3D 3D 68 08 01 72 00 51 20 02 82 4D 02 04 00 88 00 00 04 07 00 00 00 00 0C 15 03 00 00 00 0B 2E 00 00 00 0B 3B 00 00 00 0A 5A 88 12 0A 5E 16 05 0B 61 23 77 00 02 6C 8C 11 02 27 37 0D 0F 60 00 67 16";
         let csv_output = parse_to_csv(input, None);
 
-        let expected = "FrameType,Function,Address,Identification Number,Manufacturer,Access Number,Status,Security Mode,Version,Device Type,DataPoint1_Value,DataPoint1_Info,DataPoint2_Value,DataPoint2_Info,DataPoint3_Value,DataPoint3_Info,DataPoint4_Value,DataPoint4_Info,DataPoint5_Value,DataPoint5_Info,DataPoint6_Value,DataPoint6_Info,DataPoint7_Value,DataPoint7_Info,DataPoint8_Value,DataPoint8_Info,DataPoint9_Value,DataPoint9_Info,DataPoint10_Value,DataPoint10_Info\nLongFrame,\"RspUd (ACD: false, DFC: false)\",Primary (1),02205100,SLB,0,\"Permanent error, Manufacturer specific 3\",No encryption used,2,Heat Meter (Return),(0)e4[Wh],\"0,Inst,32-bit Integer\",(3)e-1[m³](Volume),\"0,Inst,BCD 8-digit\",(0)e3[W],\"0,Inst,BCD 6-digit\",(0)e-3[m³h⁻¹],\"0,Inst,BCD 6-digit\",(1288)e-1[°C],\"0,Inst,BCD 4-digit\",(516)e-1[°C],\"0,Inst,BCD 4-digit\",(7723)e-2[°K],\"0,Inst,BCD 6-digit\",(12/Jan/12)(Date),\"0,Inst,Date Type G\",(3383)[day],\"0,Inst,16-bit Integer\",\"(Manufacturer Specific: [15, 96, 0])\",None\n";
+        let expected = "FrameType,Function,Address,Identification Number,Manufacturer,Access Number,Status,Security Mode,Version,Device Type,DataPoint1_Value,DataPoint1_Info,DataPoint2_Value,DataPoint2_Info,DataPoint3_Value,DataPoint3_Info,DataPoint4_Value,DataPoint4_Info,DataPoint5_Value,DataPoint5_Info,DataPoint6_Value,DataPoint6_Info,DataPoint7_Value,DataPoint7_Info,DataPoint8_Value,DataPoint8_Info,DataPoint9_Value,DataPoint9_Info,DataPoint10_Value,DataPoint10_Info\nLongFrame,\"RspUd (ACD: false, DFC: false)\",Primary (1),02205100,SLB,0,\"Permanent error, Manufacturer specific 3\",No encryption used,2,Heat Meter (Return),(0)e4[Wh],\"0,Inst,32-bit Integer\",(3)e-1[m³](Volume),\"0,Inst,BCD 8-digit\",(0)e3[W],\"0,Inst,BCD 6-digit\",(0)e-3[m³h⁻¹],\"0,Inst,BCD 6-digit\",(1288)e-1[°C](FlowTemperature),\"0,Inst,BCD 4-digit\",(516)e-1[°C](ReturnTemperature),\"0,Inst,BCD 4-digit\",(7723)e-2[°K](TemperatureDifference),\"0,Inst,BCD 6-digit\",(12/Jan/12)(Date),\"0,Inst,Date Type G\",(3383)[day],\"0,Inst,16-bit Integer\",\"(Manufacturer Specific: [15, 96, 0])\",None\n";
 
         assert_eq!(csv_output, expected);
     }
@@ -1710,8 +1710,9 @@ mod tests {
         // Data point verifications
         assert!(table_output.contains("(0)e4[Wh]"));
         assert!(table_output.contains("(3)e-1[m³](Volume)"));
-        assert!(table_output.contains("(1288)e-1[°C]"));
+        assert!(table_output.contains("(1288)e-1[°C](FlowTemperature)"));
         assert!(table_output.contains("(12/Jan/12)(Date)"));
         assert!(table_output.contains("(3383)[day]"));
     }
+
 }


### PR DESCRIPTION
Includes suggested change to make unknown VIFE processing to just default to Reserved rather than throwing an Unimplemented error as M-Bus is an ever-evolving protocol and various vendors can always add more codes.

Other changes
- Voltage/Ampere correction as per OMS spec

<img width="942" height="114" alt="Screenshot From 2026-03-26 15-18-11" src="https://github.com/user-attachments/assets/9708d33c-37c5-493d-8d2e-24398459ef4d" />
<img width="944" height="132" alt="Screenshot From 2026-03-26 15-17-59" src="https://github.com/user-attachments/assets/37054433-a85c-48de-9700-0066ccf015a3" />

- detailing of Temperature forms for VIFs
- American unit handling for VIFE and / min macro
- 0x20 misinterpreted as ft3 moved to Reserved, `E010 0000` is meant to be reserved

Based on https://m-bus.com/documentation-wired/08-appendix and `libmbus` implementation where applicable.